### PR TITLE
Add 8-bit palette interpolation function and comparative example.

### DIFF
--- a/colorutils.cpp
+++ b/colorutils.cpp
@@ -443,6 +443,69 @@ CRGB ColorFromPalette( const CRGBPalette16& pal, uint8_t index, uint8_t brightne
     return CRGB( red1, green1, blue1);  
 }
 
+CRGB ColorFromPaletteExtended( const CRGBPalette16& pal, uint16_t index, uint8_t brightness, TBlendType blendType)
+{
+    // This fucnction has the same intuitive behavior as the other ColorFromPalette
+    // functions, except it provides 8-bit interpolation between palette entries.
+
+    // Extract the four most significant bits of the index as a palette index.
+    uint8_t index_4bit = (index >> 12);
+
+    // Calculate the 8-bit offset from the palette index.
+    // Throws away the 4 least significant bits and uses the middle 8.
+    uint8_t offset = (uint8_t)(index >> 4);
+
+    // Get the palette entry from the 4-bit index
+    //  CRGB rgb1 = pal[ hi4];
+    const CRGB* entry = &(pal[0]) + index_4bit;
+    uint8_t red1   = entry->red;
+    uint8_t green1 = entry->green;
+    uint8_t blue1  = entry->blue;
+
+    uint8_t blend = offset && (blendType != NOBLEND);
+
+    if( blend ) {
+        // If palette blending is enabled, use the offset to interpolate between
+        // the selected palette entry and the next.
+
+        if( index_4bit == 15 ) {
+            entry = &(pal[0]);
+        } else {
+            entry++;
+        }
+
+        // Calculate the scaling factor and scaled values for the lower palette value.
+
+        uint8_t f1 = 256 - offset;
+
+        red1   = scale8_LEAVING_R1_DIRTY( red1,   f1);
+        green1 = scale8_LEAVING_R1_DIRTY( green1, f1);
+        blue1  = scale8_LEAVING_R1_DIRTY( blue1,  f1);
+
+        // Calculate the scaled values for the neighboring palette value.
+        uint8_t red2   = entry->red;
+        uint8_t green2 = entry->green;
+        uint8_t blue2  = entry->blue;
+        red2   = scale8_LEAVING_R1_DIRTY( red2,   offset);
+        green2 = scale8_LEAVING_R1_DIRTY( green2, offset);
+        blue2  = scale8_LEAVING_R1_DIRTY( blue2,  offset);
+
+        cleanup_R1();
+
+        // These sums can't overflow, so no qadd8 needed.
+        red1   += red2;
+        green1 += green2;
+        blue1  += blue2;
+
+    }
+
+    if( brightness != 255) {
+        nscale8x3_video( red1, green1, blue1, brightness);
+    }
+
+    return CRGB( red1, green1, blue1);
+}
+
 
 CRGB ColorFromPalette( const CRGBPalette256& pal, uint8_t index, uint8_t brightness, TBlendType)
 {

--- a/colorutils.h
+++ b/colorutils.h
@@ -746,10 +746,17 @@ public:
 
 typedef enum { NOBLEND=0, BLEND=1 } TBlendType;
 
+// Functions to retrieve single colors
 CRGB ColorFromPalette( const CRGBPalette16& pal,
                        uint8_t index,
                        uint8_t brightness=255,
                        TBlendType blendType=BLEND);
+
+// 8-bit interpolating version of ColorFromPalette for 16-color compact palettes.
+CRGB ColorFromPaletteExtended( const CRGBPalette16& pal,
+                               uint16_t index,
+                               uint8_t brightness=255,
+                               TBlendType blendType=BLEND);
 
 CRGB ColorFromPalette( const CRGBPalette256& pal,
                        uint8_t index,

--- a/examples/SmoothPalette/SmoothPalette.ino
+++ b/examples/SmoothPalette/SmoothPalette.ino
@@ -1,0 +1,92 @@
+#include <FastLED.h>
+
+#define LED_PIN     3
+#define NUM_LEDS    25
+#define BRIGHTNESS  255
+#define LED_TYPE    WS2811
+#define COLOR_ORDER RGB
+CRGB leds[NUM_LEDS];
+
+#define UPDATES_PER_SECOND 40
+
+// This example demonstrates use of the 8-bit interpolating color retrieval from
+// compact palettes.  For basic compact palette use, consult the ColorPalette
+// example.
+
+// Smooth palette indexing uses the 12 most significant bits of a 16-bit integer.
+// As such, the difference in index between the first color in the palette and
+// the first interpolation step between this color and the next color is 16.
+// In practice, this just means that when you would increment a 16-color palette
+// index by, say, n, you would increment by n << 4 instead.
+
+CRGBPalette16 palette;
+TBlendType    currentBlending;
+uint8_t motionSpeed;
+uint16_t motionSpeedSmooth;
+uint8_t useSmoothInterpolation;
+
+
+void setup() {
+  delay( 3000 ); // power-up safety delay
+  FastLED.addLeds<LED_TYPE, LED_PIN, COLOR_ORDER>(leds, NUM_LEDS).setCorrection( TypicalLEDStrip );
+  FastLED.setBrightness(  BRIGHTNESS );
+
+  // Use a "stripe palette"; they effectively demonstrate the poor low-speed
+  // animation quality of 4-bit palette interpolation.
+  palette = RainbowStripeColors_p;
+
+  //
+  motionSpeed = 1;
+  // With smooth interpolation we can achieve much slower animation motion
+  // but retain high framerate.
+  motionSpeedSmooth = 128;
+
+}
+
+
+void loop()
+{
+
+  // Every 20 seconds switch between 4-bit interpolation and 8-bit interpolation
+  useSmoothInterpolation = (millis() / 20000) % 2;
+
+  static uint16_t startIndex = 0;
+  static uint16_t startIndexSmooth = 0;
+
+  startIndex = startIndex + motionSpeed;
+  startIndexSmooth = startIndexSmooth + motionSpeedSmooth;
+
+  if (useSmoothInterpolation) {
+    FillLEDsFromPaletteColorsSmooth( startIndexSmooth);
+  }
+  else {
+    FillLEDsFromPaletteColors( startIndex);
+  }
+
+  FastLED.show();
+  FastLED.delay(1000 / UPDATES_PER_SECOND);
+}
+
+void FillLEDsFromPaletteColors( uint8_t colorIndex)
+{
+  uint8_t brightness = 255;
+  for( int i = 0; i < NUM_LEDS; i++) {
+    leds[i] = ColorFromPalette( palette, colorIndex, brightness, BLEND);
+
+    // this line determines how much of the palette is rendered into the LEDs
+    // with 25 LEDs this implies a width of 75/256, or about 1/3 of the palette.
+    colorIndex += 3;
+  }
+}
+
+void FillLEDsFromPaletteColorsSmooth( uint16_t colorIndex)
+{
+  uint8_t brightness = 255;
+  for( int i = 0; i < NUM_LEDS; i++) {
+    leds[i] = ColorFromPaletteExtended( palette, colorIndex, brightness, BLEND);
+
+    // this line determines how much of the palette is rendered into the LEDs
+    // with 25 LEDs this implies a width of 19200/65536, or about 1/3 of the palette.
+    colorIndex += 768;
+  }
+}


### PR DESCRIPTION
Also slightly enhanced documentation in colorutils.cpp.  The SmoothPalette
example directly compares the low-speed animation quality performance of 4-bit
interpolation vs. 8-bit interpolation.  8-bit interpolation is essentially
exactly as efficient as 4-bit as the scale functions are already 8-bit.  This
enables the use of compact palettes as useful tools in the creation of
animations that are designed to run at very slow rates.